### PR TITLE
fixing option documentation

### DIFF
--- a/client.js
+++ b/client.js
@@ -6,10 +6,7 @@ const DatStorageClient = require('dat-storage-client')
 
 const debug = require('debug')('dat-store:client')
 
-// URL for storage provider running on localhost
-const LOCAL_SERVICE = 'http://localhost:3472'
-
-const ERROR_NOT_LOCAL = (service, localService) => `Provider ${service} must be running on ${this.localService} to clone`
+const ERROR_NOT_LOCAL = (service, localService) => `Provider ${service} must be running on ${localService} to clone`
 const ERROR_NO_PROVIDER = (provider) => `Provider URL not set for ${provider}`
 const ERROR_NOT_DAT_DIRECTORY = (path) => `No Dat information found in ${path}`
 const ERROR_NOT_DAT = (key) => `Key must be a hyper:// URL, instead it's ${key}`
@@ -28,7 +25,7 @@ class StoreClient {
       options.cwd = configLocation
     }
 
-    this.localService = localService || LOCAL_SERVICE
+    this.localService = localService
 
     this.config = new Conf(options)
   }

--- a/service.js
+++ b/service.js
@@ -1,70 +1,12 @@
-const PinServer = require('./server')
-
-const yargs = require('yargs')
-
-const argv = yargs
-  .command('$0', 'Start the store service')
-  .option('storage-location', {
-    describe: 'The folder to store dats in'
-  })
-  .option('port', {
-    describe: 'The port to use for the HTTP API',
-    default: 3472
-  })
-  .option('host', {
-    describe: 'The hostname to make the HTTP server listen on'
-  })
-  .option('verbose', {
-    describe: 'Whether the HTTP server should output logs',
-    default: true,
-    type: 'boolean'
-  })
-  .option('p2p-port', {
-    describe: 'The port to listen for P2P connections on',
-    default: 3282
-  })
-  .option('latest', {
-    describe: 'Whether to download just the latest changes',
-    default: false,
-    type: 'boolean'
-  })
-  .option('allow-cors', {
-    describe: 'Allow CORS requests so any website can talk to the store',
-    default: false,
-    type: 'boolean'
-  })
-  .option('expose-to-internet', {
-    describe: 'Allow connections from the internet, not just the localhost',
-    default: false,
-    type: 'boolean'
-  })
-  .option('authentication-username', {
-    describe: 'Require users to use Basic Auth with this username to connect',
-    default: '',
-    type: 'string'
-  })
-  .option('authentication-password', {
-    describe: 'Require users to use Basic Auth with this password to connect',
-    default: '',
-    type: 'password'
-  })
-  .option('manifest-timeout', {
-    describe: 'time out if the PDA cannot be read with timeout milliseconds',
-    default: 500
-  })
-  .argv
-
+const StoreServer = require('./server')
 const service = require('os-service')
 
-service.run(() => {
-  service.stop()
-})
-
-run().catch((e) => {
-  console.error(e)
-  process.exit(1)
-})
-
-async function run () {
-  await PinServer.createServer(argv)
+module.exports = function run (args) {
+  service.run(() => {
+    service.stop()
+  })
+  StoreServer.createServer(args).catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
 }


### PR DESCRIPTION
When looking over the documentation of the commands, I noticed that the service options were defined twice; used for the server options for the client options and missed the documentation for all the positional options.

This PR should fix the documentation for the dat store.